### PR TITLE
Add initial Vite React UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>BCVision Hasher</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bcvision-interface",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.4.0"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,49 @@
+.container {
+  font-family: sans-serif;
+  padding: 1rem;
+}
+
+.row {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.row input {
+  flex: 1;
+}
+
+.remove {
+  background: none;
+  border: none;
+  color: red;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.hash {
+  margin-left: 0.5rem;
+}
+
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.modal-content {
+  background: white;
+  padding: 1rem;
+  border-radius: 4px;
+  max-width: 400px;
+}
+
+.modal-content button {
+  margin-top: 1rem;
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import './App.css';
+
+async function sha256(message) {
+  const msgBuffer = new TextEncoder().encode(message);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', msgBuffer);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map(b => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+export default function App() {
+  const [rows, setRows] = useState([{ key: '', value: '' }]);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [hash, setHash] = useState('');
+
+  const addRow = () => setRows([...rows, { key: '', value: '' }]);
+  const removeRow = (index) =>
+    setRows(rows.filter((_, i) => i !== index));
+  const updateRow = (index, field, value) => {
+    const newRows = rows.slice();
+    newRows[index][field] = value;
+    setRows(newRows);
+  };
+
+  const handleHash = async () => {
+    const obj = rows.reduce((acc, { key, value }) => {
+      if (key) acc[key] = value;
+      return acc;
+    }, {});
+    const json = JSON.stringify(obj);
+    const h = await sha256(json);
+    setHash(h);
+    setModalOpen(true);
+  };
+
+  return (
+    <div className="container">
+      <h1>BCVision Hasher</h1>
+      {rows.map((row, index) => (
+        <div className="row" key={index}>
+          <input
+            type="text"
+            placeholder="clé"
+            value={row.key}
+            onChange={(e) => updateRow(index, 'key', e.target.value)}
+          />
+          <input
+            type="text"
+            placeholder="valeur"
+            value={row.value}
+            onChange={(e) => updateRow(index, 'value', e.target.value)}
+          />
+          <button className="remove" onClick={() => removeRow(index)}>×</button>
+        </div>
+      ))}
+      <button onClick={addRow}>Ajouter une ligne</button>
+      <button className="hash" onClick={handleHash}>Hasher</button>
+
+      {modalOpen && (
+        <div className="modal">
+          <div className="modal-content">
+            <p><strong>Hash SHA-256 :</strong></p>
+            <p>{hash}</p>
+            <button onClick={() => setModalOpen(false)}>Fermer</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,3 @@
+body {
+  margin: 0;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- bootstrap Vite + React project
- implement UI to enter key/value pairs
- compute SHA-256 hash of the resulting JSON and display it in a modal

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685e4eec0d9483219b1763d3843ba636