### PR TITLE
Add simulated Ethereum and Solana environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # BCVision
-Trying to implement interoperability between blockchain
+
+This project simulates small Ethereum and Solana environments used to anchor diploma hashes.
+
+## Scripts
+
+- `npm run dev` – start the Vite client and both local blockchains in parallel.
+- `npm run deploy:eth --prefix servers` – deploy the Ethereum contract.
+- `npm run deploy:solana --prefix servers` – deploy the Solana program.
+- `npm run store_hash --prefix servers -- <blockchain> <hash> <key>` – store a diploma hash.
+- `npm run get_hash --prefix servers -- <blockchain> <wallet>` – retrieve a hash.
+- `npm run verify_diploma --prefix servers -- <hash> <wallet> <blockchain>` – verify ownership.
+
+Diplomas and addresses are stored in `servers/diplomas.json` and `servers/addresses.json`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "bcvision-root",
+  "private": true,
+  "scripts": {
+    "dev": "concurrently \"npm start --prefix servers\" \"npm run dev --prefix client\""
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1"
+  }
+}

--- a/servers/addresses.json
+++ b/servers/addresses.json
@@ -1,0 +1,4 @@
+{
+  "ethereum": {"contract": "", "wallet": ""},
+  "solana": {"program": "", "wallet": ""}
+}

--- a/servers/diplomas.json
+++ b/servers/diplomas.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "Alice",
+    "degree": "Master Data",
+    "institution": "Université Test",
+    "year": 2025,
+    "hash": "0fb796ba6f5c959ada220a54095546e7d53dd565eb5c1486ee6f7880fe77c707"
+  },
+  {
+    "name": "Bob",
+    "degree": "Bachelor CS",
+    "institution": "Université Test",
+    "year": 2024,
+    "hash": "64ace9e81025b34554ad311402248eb2b62a768f05a58cd5a5b83a6f88bd57d7"
+  }
+]

--- a/servers/eth/contracts/Diploma.sol
+++ b/servers/eth/contracts/Diploma.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+contract DiplomaRegistry {
+    mapping(address => string) private diplomas;
+
+    function storeHash(string calldata hash) external {
+        diplomas[msg.sender] = hash;
+    }
+
+    function getHash(address wallet) external view returns (string memory) {
+        return diplomas[wallet];
+    }
+}

--- a/servers/eth/hardhat.config.js
+++ b/servers/eth/hardhat.config.js
@@ -1,0 +1,10 @@
+require("@nomicfoundation/hardhat-toolbox");
+
+module.exports = {
+  solidity: "0.8.20",
+  networks: {
+    localhost: {
+      url: "http://127.0.0.1:8545"
+    }
+  }
+};

--- a/servers/eth/package.json
+++ b/servers/eth/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "bcvision-eth",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "node": "npx hardhat node",
+    "deploy": "npx hardhat run scripts/deploy.js --network localhost"
+  },
+  "dependencies": {
+    "ethers": "^6.7.0"
+  },
+  "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
+    "hardhat": "^2.17.3"
+  }
+}

--- a/servers/eth/scripts/deploy.js
+++ b/servers/eth/scripts/deploy.js
@@ -1,0 +1,20 @@
+const hre = require("hardhat");
+const fs = require("fs");
+const path = require("path");
+
+async function main() {
+  const DiplomaRegistry = await hre.ethers.getContractFactory("DiplomaRegistry");
+  const diploma = await DiplomaRegistry.deploy();
+  await diploma.deployed();
+  console.log("Ethereum contract deployed to:", diploma.address);
+
+  const addressesPath = path.join(__dirname, "..", "..", "addresses.json");
+  const addresses = JSON.parse(fs.readFileSync(addressesPath));
+  addresses.ethereum.contract = diploma.address;
+  fs.writeFileSync(addressesPath, JSON.stringify(addresses, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/servers/get_hash.js
+++ b/servers/get_hash.js
@@ -1,0 +1,6 @@
+const { getHash } = require('./interactions');
+const [,, blockchain, wallet] = process.argv;
+getHash(blockchain, wallet).then(console.log).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/servers/interactions.js
+++ b/servers/interactions.js
@@ -1,0 +1,66 @@
+const fs = require('fs');
+const path = require('path');
+const { ethers } = require('ethers');
+const anchor = require('@project-serum/anchor');
+const { Keypair } = require('@solana/web3.js');
+
+const addressesPath = path.join(__dirname, 'addresses.json');
+const addresses = JSON.parse(fs.readFileSync(addressesPath));
+
+async function storeHash(blockchain, hash, key) {
+  if (blockchain === 'ethereum') {
+    const provider = new ethers.JsonRpcProvider('http://127.0.0.1:8545');
+    const wallet = new ethers.Wallet(key, provider);
+    const artifact = require('./eth/artifacts/contracts/Diploma.sol/DiplomaRegistry.json');
+    const contract = new ethers.Contract(addresses.ethereum.contract, artifact.abi, wallet);
+    const tx = await contract.storeHash(hash);
+    await tx.wait();
+    addresses.ethereum.wallet = wallet.address;
+    fs.writeFileSync(addressesPath, JSON.stringify(addresses, null, 2));
+    console.log('Stored hash on Ethereum for', wallet.address);
+  } else if (blockchain === 'solana') {
+    const connection = new anchor.web3.Connection('http://127.0.0.1:8899', 'confirmed');
+    const secret = JSON.parse(fs.readFileSync(key));
+    const wallet = new anchor.Wallet(Keypair.fromSecretKey(new Uint8Array(secret)));
+    const provider = new anchor.AnchorProvider(connection, wallet, {});
+    anchor.setProvider(provider);
+    const idl = JSON.parse(fs.readFileSync(path.join(__dirname, 'solana', 'target', 'idl', 'diploma.json')));
+    const programId = new anchor.web3.PublicKey(addresses.solana.program);
+    const program = new anchor.Program(idl, programId, provider);
+    const diploma = Keypair.generate();
+    await program.methods.storeHash(hash).accounts({
+      diploma: diploma.publicKey,
+      authority: wallet.publicKey,
+      systemProgram: anchor.web3.SystemProgram.programId
+    }).signers([diploma]).rpc();
+    addresses.solana.wallet = wallet.publicKey.toBase58();
+    fs.writeFileSync(addressesPath, JSON.stringify(addresses, null, 2));
+    console.log('Stored hash on Solana for', wallet.publicKey.toBase58());
+  }
+}
+
+async function getHash(blockchain, walletAddr) {
+  if (blockchain === 'ethereum') {
+    const provider = new ethers.JsonRpcProvider('http://127.0.0.1:8545');
+    const artifact = require('./eth/artifacts/contracts/Diploma.sol/DiplomaRegistry.json');
+    const contract = new ethers.Contract(addresses.ethereum.contract, artifact.abi, provider);
+    const hash = await contract.getHash(walletAddr);
+    return hash;
+  } else if (blockchain === 'solana') {
+    const connection = new anchor.web3.Connection('http://127.0.0.1:8899', 'confirmed');
+    const idl = JSON.parse(fs.readFileSync(path.join(__dirname, 'solana', 'target', 'idl', 'diploma.json')));
+    const programId = new anchor.web3.PublicKey(addresses.solana.program);
+    const provider = new anchor.AnchorProvider(connection, new anchor.Wallet(Keypair.generate()), {});
+    const program = new anchor.Program(idl, programId, provider);
+    const diplomaPubkey = new anchor.web3.PublicKey(walletAddr);
+    const account = await program.account.diploma.fetch(diplomaPubkey);
+    return account.hash;
+  }
+}
+
+async function verifyDiploma(hash, walletAddr, blockchain) {
+  const stored = await getHash(blockchain, walletAddr);
+  return stored === hash;
+}
+
+module.exports = { storeHash, getHash, verifyDiploma };

--- a/servers/package.json
+++ b/servers/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "bcvision-servers",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "concurrently \"npm run node --prefix eth\" \"npm run node --prefix solana\"",
+    "deploy:eth": "npm run deploy --prefix eth",
+    "deploy:solana": "npm run deploy --prefix solana",
+    "store_hash": "node store_hash.js",
+    "get_hash": "node get_hash.js",
+    "verify_diploma": "node verify_diploma.js"
+  },
+  "devDependencies": {
+    "concurrently": "^8.0.1"
+  },
+  "dependencies": {
+    "@project-serum/anchor": "^0.28.0",
+    "ethers": "^6.7.0"
+  }
+}

--- a/servers/solana/Anchor.toml
+++ b/servers/solana/Anchor.toml
@@ -1,0 +1,6 @@
+[programs.localnet]
+diploma = "diploma"
+
+[provider]
+cluster = "localnet"
+wallet = "~/.config/solana/id.json"

--- a/servers/solana/migrations/deploy.js
+++ b/servers/solana/migrations/deploy.js
@@ -1,0 +1,14 @@
+const anchor = require('@project-serum/anchor');
+const fs = require('fs');
+const path = require('path');
+
+module.exports = async function (provider) {
+  anchor.setProvider(provider);
+  const program = anchor.workspace.Diploma;
+  console.log('Solana program deployed to:', program.programId.toBase58());
+
+  const addressesPath = path.join(__dirname, '..', 'addresses.json');
+  const addresses = JSON.parse(fs.readFileSync(addressesPath));
+  addresses.solana.program = program.programId.toBase58();
+  fs.writeFileSync(addressesPath, JSON.stringify(addresses, null, 2));
+};

--- a/servers/solana/package.json
+++ b/servers/solana/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "bcvision-solana",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "anchor build",
+    "deploy": "anchor deploy",
+    "node": "solana-test-validator"
+  },
+  "dependencies": {
+    "@project-serum/anchor": "^0.28.0"
+  }
+}

--- a/servers/solana/programs/diploma/Cargo.toml
+++ b/servers/solana/programs/diploma/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "diploma"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+anchor-lang = "0.28.0"

--- a/servers/solana/programs/diploma/src/lib.rs
+++ b/servers/solana/programs/diploma/src/lib.rs
@@ -1,0 +1,29 @@
+use anchor_lang::prelude::*;
+
+declare_id!("Fg6PaFpoGXkYsidMpWTK6W2BeZ7FEfcYkgz5k4Gh2ySZ");
+
+#[program]
+pub mod diploma {
+    use super::*;
+    pub fn store_hash(ctx: Context<StoreHash>, hash: String) -> Result<()> {
+        let diploma = &mut ctx.accounts.diploma;
+        diploma.owner = *ctx.accounts.authority.key;
+        diploma.hash = hash;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct StoreHash<'info> {
+    #[account(init, payer = authority, space = 8 + 32 + 64)]
+    pub diploma: Account<'info, Diploma>,
+    #[account(mut)]
+    pub authority: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct Diploma {
+    pub owner: Pubkey,
+    pub hash: String,
+}

--- a/servers/store_hash.js
+++ b/servers/store_hash.js
@@ -1,0 +1,6 @@
+const { storeHash } = require('./interactions');
+const [,, blockchain, hash, key] = process.argv;
+storeHash(blockchain, hash, key).catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/servers/verify_diploma.js
+++ b/servers/verify_diploma.js
@@ -1,0 +1,8 @@
+const { verifyDiploma } = require('./interactions');
+const [,, hash, wallet, blockchain] = process.argv;
+verifyDiploma(hash, wallet, blockchain).then(result => {
+  console.log(result);
+}).catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add demo diplomas with SHA256 hashes
- create Hardhat project for Ethereum with basic DiplomaRegistry contract
- create Anchor-based Solana program to store diploma hashes
- provide scripts to deploy, store, retrieve and verify diploma hashes
- add server and root `package.json` files with concurrent start scripts
- update README with new instructions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685e560435a08321b5c8efeee6f23a20